### PR TITLE
Require typo3-core extension only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,15 @@
     "type": "typo3-cms-extension",
     "description": "TYPO3 Logging API reading module and devlog extension in one",
     "license": "GPL-2.0+",
+    "require": {
+        "php": ">=5.4",
+        "typo3/cms-core": "^8.7 || ^9.0",
+        "psr/log": "^1.0"
+    },
     "autoload": {
         "psr-4": {
             "VerteXVaaR\\Logs\\": "Classes/"
         }
-    },
-    "require": {
-        "php": ">=5.4",
-        "typo3/cms": "^8.7 || ^9.0",
-        "psr/log": "^1.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
According to https://composer.typo3.org/ "Add your own composer.json file" an extension should only require the core extension (and maybe others) instead of the whole TYPO3 distribution.

This has the advantage that you can select single core extensions individually.