### PR TITLE
[BUGFIX] TYPO3v9 can not handle phpdoc annotation @param int|null

### DIFF
--- a/Classes/Domain/Model/Filter.php
+++ b/Classes/Domain/Model/Filter.php
@@ -121,11 +121,11 @@ class Filter
     }
 
     /**
-     * @param int|null $fromTime
+     * @param int $fromTime
      */
-    public function setFromTime(int $fromTime = null)
+    public function setFromTime(int $fromTime = 0)
     {
-        $this->fromTime = (int)$fromTime;
+        $this->fromTime = $fromTime;
     }
 
     /**
@@ -137,11 +137,11 @@ class Filter
     }
 
     /**
-     * @param int|null $toTime
+     * @param int $toTime
      */
-    public function setToTime(int $toTime = null)
+    public function setToTime(int $toTime = 0)
     {
-        $this->toTime = (int)$toTime;
+        $this->toTime = $toTime;
     }
 
     /**


### PR DESCRIPTION
TYPO3v9 throws an exception with "Could not find a suitable type converter for "int|null" because no such class or interface exists".

I changed int|null to int because null should not happen at all. 

Default values for this properties is int 0. 
Within setter-funcs null values would be casted to int 0. So i think this should not make a difference. 